### PR TITLE
Fix ERR_INVALID_CALLBACK error on Node v10+

### DIFF
--- a/bin/readme-kanban-board.js
+++ b/bin/readme-kanban-board.js
@@ -118,8 +118,13 @@ Promise.all([promisedCSS, promisedMD])
         } else {
           // Bosh it into the README.md
           md = utils.addImageToMarkdown(pathGenImage, md);
-          fs.writeFile(pathReadme, md);
-          console.log('README.md updated with your kanban image!');
+          fs.writeFile(pathReadme, md, (err) => {
+            if (err) {
+              console.log(err);
+              return;
+            }
+            console.log('README.md updated with your kanban image!');
+          });
         }
       }
     );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "readme-kanban-board",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Write a markdown based kanban board and have it converted to a nice image in your readme",
   "main": "bin/readme-kanban-board.js",
   "scripts": {


### PR DESCRIPTION
In Node v10, [the `callback` parameter in `fs.writeFile` was made mandatory](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback).

This PR adds this callback, thus fixing #1 . The error handling pattern is consistent with other error handlers on this codebase.

`npm run build` and `npm run dev` worked with no issues. The resulting image looks correct.